### PR TITLE
Correct val name in search example

### DIFF
--- a/_posts/2016-01-23-http.md
+++ b/_posts/2016-01-23-http.md
@@ -18,7 +18,7 @@ Let's look at a small example, in which we have a search field and want to acces
 {% highlight scala %}
 val queries = createStringHandler()
 
-val requests = inputs
+val requests = queries
   .map(query => s"https://someurl.org?query=$query")
   .debounceTime(300 millis)
 


### PR DESCRIPTION
Hi there,

Just noticed what seems to have been a typo in the simple HTTP example.

Have a good day.